### PR TITLE
Implement MLM commission backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# Create-Form-
+# MLM Course Commission Backend
+
+This repository provides a Python implementation of a 4-level affiliate/MLM commission
+structure for a ₹3000 stock market crash course. The business rules implemented are:
+
+- ₹1000 from every sale goes to the company. The remaining ₹2000 are distributed
+  across four affiliate levels.
+- Level payouts: level 1 ₹1000, level 2 ₹250, level 3 ₹250, level 4 ₹500.
+- Level activation thresholds: level 1 unlocked immediately, level 2 after 10 direct
+  referrals, level 3 after 25 direct referrals, level 4 after 50 direct referrals.
+- When a level is not yet unlocked the potential commission is tracked as *pending*
+  and is released automatically once the direct referral requirement is met.
+
+## Project layout
+
+```
+mlm_backend/
+├── config.py         # Commission plan configuration
+├── models.py         # Dataclasses describing users and commission records
+├── repository.py     # In-memory repository abstraction
+└── service.py        # Business logic for registrations and payouts
+main.py               # Demonstration script
+```
+
+## Usage
+
+The simplest way to explore the behaviour is to run the demo script:
+
+```bash
+python main.py
+```
+
+It bootstraps a small network, unlocks higher level commissions for the
+`sponsor`, and prints two sample dashboards.
+
+For programmatic access instantiate the service directly:
+
+```python
+from mlm_backend import InMemoryUserRepository, MLMService
+
+repo = InMemoryUserRepository()
+service = MLMService(user_repo=repo)
+
+service.register_user(user_id="company", name="Company")
+service.register_user(user_id="mentor", name="Mentor", referrer_id="company")
+service.register_user(user_id="student", name="Student", referrer_id="mentor")
+
+dashboard = service.get_dashboard("mentor")
+print(dashboard.available_balance, dashboard.pending_balance)
+```
+
+## Running the tests
+
+The repository contains unit tests that validate commission distribution and the
+unlocking logic. To execute them run:
+
+```bash
+python -m pytest
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,38 @@
+"""Example script demonstrating the MLM backend logic."""
+from pprint import pprint
+
+from mlm_backend import InMemoryUserRepository, MLMService
+
+
+def bootstrap_demo() -> None:
+    repo = InMemoryUserRepository()
+    service = MLMService(user_repo=repo)
+
+    # Company/root user without a referrer.
+    service.register_user(user_id="company", name="Company")
+
+    # First affiliate directly connected to company.
+    service.register_user(user_id="mentor", name="Mentor", referrer_id="company")
+
+    # Downline chain to showcase multi-level distribution.
+    service.register_user(user_id="trader_a", name="Trader A", referrer_id="mentor")
+    service.register_user(user_id="trader_b", name="Trader B", referrer_id="trader_a")
+    service.register_user(user_id="trader_c", name="Trader C", referrer_id="trader_b")
+
+    # Enroll additional direct partners for mentor to unlock level 2 earnings.
+    for index in range(1, 10):
+        service.register_user(
+            user_id=f"mentor_ref_{index}",
+            name=f"Mentor Referral {index}",
+            referrer_id="mentor",
+        )
+
+    print("=== Mentor dashboard ===")
+    pprint(service.get_dashboard("mentor"))
+
+    print("\n=== Company dashboard ===")
+    pprint(service.get_dashboard("company"))
+
+
+if __name__ == "__main__":
+    bootstrap_demo()

--- a/mlm_backend/__init__.py
+++ b/mlm_backend/__init__.py
@@ -1,0 +1,28 @@
+"""MLM backend package."""
+
+from .config import COMMISSION_PLAN, COMPANY_SHARE, COURSE_PRICE, LevelConfig
+from .models import (
+    CommissionRecord,
+    CommissionStatus,
+    DashboardLevelSummary,
+    DashboardSummary,
+    User,
+)
+from .repository import InMemoryUserRepository, UserAlreadyExists, UserNotFound
+from .service import MLMService
+
+__all__ = [
+    "COMMISSION_PLAN",
+    "COMPANY_SHARE",
+    "COURSE_PRICE",
+    "LevelConfig",
+    "CommissionRecord",
+    "CommissionStatus",
+    "DashboardLevelSummary",
+    "DashboardSummary",
+    "User",
+    "InMemoryUserRepository",
+    "UserAlreadyExists",
+    "UserNotFound",
+    "MLMService",
+]

--- a/mlm_backend/config.py
+++ b/mlm_backend/config.py
@@ -1,0 +1,24 @@
+"""Configuration for the MLM commission plan."""
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class LevelConfig:
+    """Represents the payout and activation requirement for a level."""
+
+    level: int
+    payout: int
+    direct_requirement: int
+
+
+COURSE_PRICE = 3000
+COMPANY_SHARE = 1000
+
+
+COMMISSION_PLAN: Dict[int, LevelConfig] = {
+    1: LevelConfig(level=1, payout=1000, direct_requirement=0),
+    2: LevelConfig(level=2, payout=250, direct_requirement=10),
+    3: LevelConfig(level=3, payout=250, direct_requirement=25),
+    4: LevelConfig(level=4, payout=500, direct_requirement=50),
+}

--- a/mlm_backend/models.py
+++ b/mlm_backend/models.py
@@ -1,0 +1,111 @@
+"""Domain models for the MLM commission system."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Iterable, List, Optional
+
+
+class CommissionStatus(str, Enum):
+    """Represents the lifecycle state of a commission."""
+
+    AVAILABLE = "available"
+    PENDING = "pending"
+
+
+@dataclass
+class CommissionRecord:
+    """Stores a commission generated from a downline purchase."""
+
+    from_user_id: str
+    level: int
+    amount: int
+    status: CommissionStatus
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    released_at: Optional[datetime] = None
+
+    def mark_available(self) -> None:
+        """Update the commission to an available state."""
+
+        if self.status == CommissionStatus.PENDING:
+            self.status = CommissionStatus.AVAILABLE
+            self.released_at = datetime.utcnow()
+
+
+@dataclass
+class Wallet:
+    """Aggregates the commissions earned by a user."""
+
+    commissions: List[CommissionRecord] = field(default_factory=list)
+
+    def add_commission(self, record: CommissionRecord) -> None:
+        self.commissions.append(record)
+
+    def release_pending(self, level: int) -> List[CommissionRecord]:
+        """Mark all pending commissions for a level as available."""
+
+        released: List[CommissionRecord] = []
+        for record in self.commissions:
+            if record.level == level and record.status == CommissionStatus.PENDING:
+                record.mark_available()
+                released.append(record)
+        return released
+
+    @property
+    def available_balance(self) -> int:
+        return sum(record.amount for record in self.commissions if record.status == CommissionStatus.AVAILABLE)
+
+    @property
+    def pending_balance(self) -> int:
+        return sum(record.amount for record in self.commissions if record.status == CommissionStatus.PENDING)
+
+    def total_by_level(self, level: int, *, status: Optional[CommissionStatus] = None) -> int:
+        records: Iterable[CommissionRecord] = (r for r in self.commissions if r.level == level)
+        if status is not None:
+            records = (r for r in records if r.status == status)
+        return sum(r.amount for r in records)
+
+
+@dataclass
+class User:
+    """Represents an affiliate in the MLM tree."""
+
+    id: str
+    name: str
+    referrer_id: Optional[str]
+    wallet: Wallet = field(default_factory=Wallet)
+    direct_referrals: List[str] = field(default_factory=list)
+
+    def add_direct_referral(self, user_id: str) -> None:
+        self.direct_referrals.append(user_id)
+
+    @property
+    def direct_referral_count(self) -> int:
+        return len(self.direct_referrals)
+
+
+@dataclass
+class DashboardLevelSummary:
+    level: int
+    requirement: int
+    direct_referrals: int
+    unlocked: bool
+    pending_amount: int
+    available_amount: int
+
+
+@dataclass
+class DashboardSummary:
+    """Serializable structure for presenting a user's dashboard."""
+
+    user_id: str
+    name: str
+    direct_referrals: int
+    available_balance: int
+    pending_balance: int
+    levels: List[DashboardLevelSummary]
+
+    @property
+    def total_balance(self) -> int:
+        return self.available_balance + self.pending_balance

--- a/mlm_backend/repository.py
+++ b/mlm_backend/repository.py
@@ -1,0 +1,47 @@
+"""Repository abstractions for managing users."""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Dict, Iterable, Optional
+
+from .models import User
+
+
+class UserAlreadyExists(Exception):
+    """Raised when attempting to create a user that already exists."""
+
+
+class UserNotFound(Exception):
+    """Raised when requesting a user that does not exist."""
+
+
+class InMemoryUserRepository:
+    """A simple in-memory repository suitable for demos and testing."""
+
+    def __init__(self) -> None:
+        self._users: Dict[str, User] = {}
+
+    def add(self, user: User) -> None:
+        if user.id in self._users:
+            raise UserAlreadyExists(f"User '{user.id}' already exists")
+        self._users[user.id] = user
+
+    def get(self, user_id: str) -> User:
+        try:
+            return self._users[user_id]
+        except KeyError as error:
+            raise UserNotFound(f"User '{user_id}' was not found") from error
+
+    def update(self, user: User) -> None:
+        if user.id not in self._users:
+            raise UserNotFound(f"User '{user.id}' was not found")
+        self._users[user.id] = user
+
+    def exists(self, user_id: str) -> bool:
+        return user_id in self._users
+
+    def all(self) -> Iterable[User]:
+        return list(self._users.values())
+
+    def clear(self) -> None:
+        self._users.clear()

--- a/mlm_backend/service.py
+++ b/mlm_backend/service.py
@@ -1,0 +1,110 @@
+"""Service layer containing the MLM business logic."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+from .config import COMMISSION_PLAN, LevelConfig
+from .models import (
+    CommissionRecord,
+    CommissionStatus,
+    DashboardLevelSummary,
+    DashboardSummary,
+    User,
+)
+from .repository import InMemoryUserRepository, UserNotFound
+
+
+@dataclass
+class MLMService:
+    """Coordinates user registrations and commission distribution."""
+
+    user_repo: InMemoryUserRepository
+    commission_plan: Dict[int, LevelConfig] = field(default_factory=lambda: dict(COMMISSION_PLAN))
+
+    def register_user(self, *, user_id: str, name: str, referrer_id: Optional[str] = None) -> User:
+        """Register a new user and trigger commission distribution."""
+
+        if referrer_id is not None:
+            # Ensure the referrer exists before creating the user.
+            self.user_repo.get(referrer_id)
+
+        user = User(id=user_id, name=name, referrer_id=referrer_id)
+        self.user_repo.add(user)
+
+        if referrer_id is not None:
+            self._attach_referral(referrer_id, user_id)
+
+        self._distribute_commissions(user_id)
+        return user
+
+    def _attach_referral(self, referrer_id: str, new_user_id: str) -> None:
+        referrer = self.user_repo.get(referrer_id)
+        referrer.add_direct_referral(new_user_id)
+        self._unlock_commissions(referrer)
+        self.user_repo.update(referrer)
+
+    def _distribute_commissions(self, new_user_id: str) -> None:
+        current_referrer_id = self.user_repo.get(new_user_id).referrer_id
+        level = 1
+        while current_referrer_id is not None and level in self.commission_plan:
+            referrer = self.user_repo.get(current_referrer_id)
+            config = self.commission_plan[level]
+            status = (
+                CommissionStatus.AVAILABLE
+                if referrer.direct_referral_count >= config.direct_requirement
+                else CommissionStatus.PENDING
+            )
+            record = CommissionRecord(
+                from_user_id=new_user_id,
+                level=level,
+                amount=config.payout,
+                status=status,
+            )
+            referrer.wallet.add_commission(record)
+            if status == CommissionStatus.AVAILABLE:
+                # Persist the updated wallet state immediately.
+                self.user_repo.update(referrer)
+            else:
+                # Pending commissions will be persisted after unlocking.
+                self.user_repo.update(referrer)
+
+            current_referrer_id = referrer.referrer_id
+            level += 1
+
+    def _unlock_commissions(self, user: User) -> None:
+        direct_count = user.direct_referral_count
+        for level, config in self.commission_plan.items():
+            if direct_count >= config.direct_requirement:
+                released = user.wallet.release_pending(level)
+                if released:
+                    # Persisting happens in caller.
+                    continue
+
+    def get_dashboard(self, user_id: str) -> DashboardSummary:
+        user = self.user_repo.get(user_id)
+        levels: List[DashboardLevelSummary] = []
+        for level, config in self.commission_plan.items():
+            unlocked = user.direct_referral_count >= config.direct_requirement
+            levels.append(
+                DashboardLevelSummary(
+                    level=level,
+                    requirement=config.direct_requirement,
+                    direct_referrals=user.direct_referral_count,
+                    unlocked=unlocked,
+                    pending_amount=user.wallet.total_by_level(level, status=CommissionStatus.PENDING),
+                    available_amount=user.wallet.total_by_level(level, status=CommissionStatus.AVAILABLE),
+                )
+            )
+
+        return DashboardSummary(
+            user_id=user.id,
+            name=user.name,
+            direct_referrals=user.direct_referral_count,
+            available_balance=user.wallet.available_balance,
+            pending_balance=user.wallet.pending_balance,
+            levels=levels,
+        )
+
+    def list_users(self) -> List[User]:
+        return list(self.user_repo.all())

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,100 @@
+"""Unit tests for the MLM service."""
+from mlm_backend import InMemoryUserRepository, MLMService
+
+
+def create_service() -> MLMService:
+    return MLMService(user_repo=InMemoryUserRepository())
+
+
+def test_single_referral_earns_level_one_commission() -> None:
+    service = create_service()
+    service.register_user(user_id="company", name="Company")
+    service.register_user(user_id="alice", name="Alice", referrer_id="company")
+
+    dashboard = service.get_dashboard("company")
+    assert dashboard.available_balance == 1000
+    assert dashboard.pending_balance == 0
+    level_one = next(level for level in dashboard.levels if level.level == 1)
+    assert level_one.available_amount == 1000
+    assert level_one.pending_amount == 0
+
+
+def test_commissions_become_pending_until_unlock() -> None:
+    service = create_service()
+    service.register_user(user_id="top", name="Top")
+    service.register_user(user_id="mid", name="Mid", referrer_id="top")
+    service.register_user(user_id="bottom", name="Bottom", referrer_id="mid")
+
+    top_dashboard = service.get_dashboard("top")
+    level_two = next(level for level in top_dashboard.levels if level.level == 2)
+    assert level_two.pending_amount == 250
+    assert top_dashboard.pending_balance == 250
+    assert top_dashboard.available_balance == 1000
+
+
+def test_unlocking_releases_pending_commissions() -> None:
+    service = create_service()
+    service.register_user(user_id="root", name="Root")
+    service.register_user(user_id="leader", name="Leader", referrer_id="root")
+
+    # Create a downline that gives leader a level 1 commission and root a pending level 2 commission.
+    service.register_user(user_id="student", name="Student", referrer_id="leader")
+
+    root_dashboard = service.get_dashboard("root")
+    assert root_dashboard.pending_balance == 250
+
+    # Add additional direct referrals for root to satisfy the level 2 requirement (10 direct referrals total).
+    for index in range(1, 10):
+        service.register_user(
+            user_id=f"root_ref_{index}",
+            name=f"Root Referral {index}",
+            referrer_id="root",
+        )
+
+    updated_dashboard = service.get_dashboard("root")
+    assert updated_dashboard.pending_balance == 0
+    level_two = next(level for level in updated_dashboard.levels if level.level == 2)
+    assert level_two.available_amount == 250
+    assert level_two.pending_amount == 0
+
+
+def test_multiple_levels_unlocking_progressively() -> None:
+    service = create_service()
+    service.register_user(user_id="root", name="Root")
+
+    # Create a chain of 4 levels.
+    service.register_user(user_id="l1", name="Level1", referrer_id="root")
+    service.register_user(user_id="l2", name="Level2", referrer_id="l1")
+    service.register_user(user_id="l3", name="Level3", referrer_id="l2")
+    service.register_user(user_id="l4", name="Level4", referrer_id="l3")
+
+    root_dashboard = service.get_dashboard("root")
+    assert root_dashboard.available_balance == 1000
+    assert root_dashboard.pending_balance == 1000  # level 2, 3, 4 pending (250 + 250 + 500)
+
+    # Unlock level 2 by adding more directs.
+    for index in range(1, 10):
+        service.register_user(user_id=f"root_l2_{index}", name=f"Root L2 {index}", referrer_id="root")
+    level2_dashboard = service.get_dashboard("root")
+    level2_summary = next(level for level in level2_dashboard.levels if level.level == 2)
+    assert level2_summary.available_amount == 250
+    assert level2_summary.pending_amount == 0
+    assert level2_dashboard.pending_balance == 750
+
+    # Unlock level 3 after 25 directs (already 10, need 15 more).
+    for index in range(10, 25):
+        service.register_user(user_id=f"root_l3_{index}", name=f"Root L3 {index}", referrer_id="root")
+    level3_dashboard = service.get_dashboard("root")
+    level3_summary = next(level for level in level3_dashboard.levels if level.level == 3)
+    assert level3_summary.available_amount == 250
+    assert level3_summary.pending_amount == 0
+    assert level3_dashboard.pending_balance == 500
+
+    # Unlock level 4 after 50 directs (already 25, need 25 more).
+    for index in range(25, 50):
+        service.register_user(user_id=f"root_l4_{index}", name=f"Root L4 {index}", referrer_id="root")
+    final_dashboard = service.get_dashboard("root")
+    level4_summary = next(level for level in final_dashboard.levels if level.level == 4)
+    assert level4_summary.available_amount == 500
+    assert level4_summary.pending_amount == 0
+    assert final_dashboard.pending_balance == 0


### PR DESCRIPTION
## Summary
- add a reusable MLM service that registers users and distributes commissions according to the four-level plan
- expose dataclasses describing users, wallets, and dashboard summaries along with a demo script for quick exploration
- document the system behaviour and add tests that cover commission distribution and unlocking logic

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce3a4cbc10832f820eba17ba9b8b82